### PR TITLE
use homespun's version of net-socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "promise": ">=7.1.1",
     "moment": ">=2.4.0",
-    "net-socket": "v1.0.0"
+    "net-socket": "homespun/net-socket"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "promise": ">=7.1.1",
     "moment": ">=2.4.0",
-    "net-socket": "homespun/net-socket"
+    "net-socket": "1.1.0"
   }
 }


### PR DESCRIPTION
which retries on ECONNRESET (in addition to ECONNREFUSED)

the official net-socket repository hasn't been updated in two years... when talking to the OSRAM Lightify bridge, i see ECONNRESET from time to time, so i've forked the net-socket repository.

it's probably best for you to fork it as well, so you can keep net-socket, node-lightify, and homebridge-lightify all under chris1705 ... just a thought.